### PR TITLE
Add jahn00 pwa domain to allow scope extensions for his pwa

### DIFF
--- a/.well-known/web-app-origin-association
+++ b/.well-known/web-app-origin-association
@@ -17,6 +17,9 @@
         },
         {
             "web_app_identity": "https://inky-waiting-beak.glitch.me/index.html"
+        },
+        {
+            "web_app_identity": "https://jahn00.github.io/pwa/index.html"
         }
     ]
 }


### PR DESCRIPTION
Adding `https://jahn00.github.io/pwa/index.html` to `web-app-origin-association` allow his PWA (https://jahn00.github.io/pwa/index.html) to extend its scope to Lu's PWA.